### PR TITLE
Added Remote execution type, modified config file parameters

### DIFF
--- a/src/main/java/com/crm/qa/base/TestBase.java
+++ b/src/main/java/com/crm/qa/base/TestBase.java
@@ -3,6 +3,8 @@ package com.crm.qa.base;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
@@ -13,6 +15,8 @@ import org.openqa.selenium.edge.EdgeDriver;
 import org.openqa.selenium.firefox.FirefoxDriver;
 import org.openqa.selenium.ie.InternetExplorerDriver;
 import org.openqa.selenium.opera.OperaDriver;
+import org.openqa.selenium.remote.DesiredCapabilities;
+import org.openqa.selenium.remote.RemoteWebDriver;
 import org.openqa.selenium.safari.SafariDriver;
 import org.openqa.selenium.support.events.EventFiringWebDriver;
 
@@ -20,59 +24,105 @@ import com.crm.qa.util.TestUtil;
 import com.crm.qa.util.WebEventListener;
 
 public class TestBase {
-	
+
 	public static WebDriver driver;
 	public static Properties prop;
-	public  static EventFiringWebDriver e_driver;
+	public static EventFiringWebDriver e_driver;
 	public static WebEventListener eventListener;
-	public static String s=File.separator;
-	
-	public TestBase(){
+	public static String s = File.separator;
+
+	public TestBase() {
 		try {
 			prop = new Properties();
-			FileInputStream ip = new FileInputStream(System.getProperty("user.dir")+s+"src"+s+"main"+s+"java"+s+"com"+s+"crm"+s+"qa"+s+"config"+s+"config.properties");
+			FileInputStream ip = new FileInputStream(System.getProperty("user.dir") + s + "src" + s + "main" + s
+					+ "java" + s + "com" + s + "crm" + s + "qa" + s + "config" + s + "config.properties");
 			prop.load(ip);
 		} catch (IOException e) {
 			e.printStackTrace();
 		}
 	}
-	
-	
-	public static void initialization(){
+
+	public static void initialization() throws MalformedURLException {
 		String browserName = prop.getProperty("browser");
-		switch(browserName)
-		{
-			case "chrome":	WebDriverManager.chromedriver().setup();
-							driver = new ChromeDriver();
-							break;
-			case "firefox": WebDriverManager.firefoxdriver().setup();
-							driver = new FirefoxDriver();
-							break;
-			case "edge":	WebDriverManager.edgedriver().setup();
-							driver = new EdgeDriver();
-							break;
-			case "explorer":WebDriverManager.iedriver().setup();
-							driver = new InternetExplorerDriver();
-							break;
-			case "opera":	WebDriverManager.operadriver().setup();
-							driver = new OperaDriver();
-							break;
-			case "safari":	driver = new SafariDriver();
-							break;
+		String environmentType = prop.getProperty("environmentType");
+
+		if (environmentType.equalsIgnoreCase("LOCAL")) {
+			driver = createLocalDriver(browserName);
+		}
+		if (environmentType.equalsIgnoreCase("REMOTE")) {
+			driver = createRemoteDriver();
 		}
 
 		e_driver = new EventFiringWebDriver(driver);
-		// Now create object of EventListerHandler to register it with EventFiringWebDriver
+		// Now create object of EventListerHandler to register it with
+		// EventFiringWebDriver
 		eventListener = new WebEventListener();
 		e_driver.register(eventListener);
 		driver = e_driver;
-		
+
 		driver.manage().window().maximize();
 		driver.manage().deleteAllCookies();
 		driver.manage().timeouts().pageLoadTimeout(TestUtil.PAGE_LOAD_TIMEOUT, TimeUnit.SECONDS);
 		driver.manage().timeouts().implicitlyWait(TestUtil.IMPLICIT_WAIT, TimeUnit.SECONDS);
-		
+
 		driver.get(prop.getProperty("url"));
+	}
+
+	private static WebDriver createRemoteDriver() throws MalformedURLException {
+		// Remote Driver Implementation
+		final String USERNAME = prop.getProperty("BrowserStackUser");		
+		final String AUTOMATE_KEY = prop.getProperty("BrowserStackAutomateKey");
+		final String URL = "https://" + USERNAME + ":" + AUTOMATE_KEY + "@hub-cloud.browserstack.com/wd/hub";
+		
+		DesiredCapabilities caps = new DesiredCapabilities();
+        
+		caps.setCapability("os", "Windows");
+		caps.setCapability("os_version", "10");
+		caps.setCapability("browser", "Chrome");
+		caps.setCapability("browser_version", "80");
+		caps.setCapability("name", "BrowserStack's Cloud Test");
+		
+		WebDriver driver = new RemoteWebDriver(new URL(URL), caps);
+		
+		return driver;
+	}
+
+	private static WebDriver createLocalDriver(String browserName) {
+
+		switch (browserName) {
+		case "chrome":
+			WebDriverManager.chromedriver().setup();
+			driver = new ChromeDriver();
+			break;
+		case "firefox":
+			WebDriverManager.firefoxdriver().setup();
+			driver = new FirefoxDriver();
+			break;
+		case "edge":
+			WebDriverManager.edgedriver().setup();
+			driver = new EdgeDriver();
+			break;
+		case "explorer":
+			WebDriverManager.iedriver().setup();
+			driver = new InternetExplorerDriver();
+			break;
+		case "opera":
+			WebDriverManager.operadriver().setup();
+			driver = new OperaDriver();
+			break;
+		case "safari":
+			driver = new SafariDriver();
+			break;
+		default:
+			System.out.println("Please provide valid browser name or browsername is empty");
+		}
+		return driver;
+	}
+
+	public void closeDriver() {
+		driver.close();
+		
+		driver.quit(); // this is exclusively required for Browserstack
 	}
 
 }

--- a/src/main/java/com/crm/qa/config/config.properties
+++ b/src/main/java/com/crm/qa/config/config.properties
@@ -4,3 +4,7 @@ username = naveenk
 password = test@123
 
 browser = chrome
+environmentType = local
+
+BrowserStackUser = venkateshsalagra1
+BrowserStackAutomateKey = yTHyXzzfY9XuQcrkL1kX

--- a/src/test/java/com/crm/qa/testcases/ContactsPageTest.java
+++ b/src/test/java/com/crm/qa/testcases/ContactsPageTest.java
@@ -5,6 +5,8 @@
 
 package com.crm.qa.testcases;
 
+import java.net.MalformedURLException;
+
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
@@ -34,7 +36,7 @@ public class ContactsPageTest extends TestBase{
 	
 	
 	@BeforeMethod
-	public void setUp() throws InterruptedException {
+	public void setUp() throws InterruptedException, MalformedURLException {
 		
 		initialization();
 		testUtil = new TestUtil();

--- a/src/test/java/com/crm/qa/testcases/FreeCrmTest.java
+++ b/src/test/java/com/crm/qa/testcases/FreeCrmTest.java
@@ -2,6 +2,7 @@ package com.crm.qa.testcases;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.MalformedURLException;
 
 import com.crm.qa.base.TestBase;
 import org.apache.commons.io.FileUtils;
@@ -20,7 +21,7 @@ public class FreeCrmTest extends TestBase {
 	static JavascriptExecutor js;
 
 	@BeforeMethod
-	public void setUp() {
+	public void setUp() throws MalformedURLException {
 		initialization();
 		js = (JavascriptExecutor) driver;
 		driver.get("https://www.freecrm.com/index.html");

--- a/src/test/java/com/crm/qa/testcases/HomePageTest.java
+++ b/src/test/java/com/crm/qa/testcases/HomePageTest.java
@@ -1,5 +1,7 @@
 package com.crm.qa.testcases;
 
+import java.net.MalformedURLException;
+
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
@@ -27,7 +29,7 @@ public class HomePageTest extends TestBase {
 	//after each test case -- close the browser
 	
 	@BeforeMethod
-	public void setUp() {
+	public void setUp() throws MalformedURLException {
 		initialization();
 		testUtil = new TestUtil();
 		contactsPage = new ContactsPage();

--- a/src/test/java/com/crm/qa/testcases/LoginPageTest.java
+++ b/src/test/java/com/crm/qa/testcases/LoginPageTest.java
@@ -1,5 +1,7 @@
 package com.crm.qa.testcases;
 
+import java.net.MalformedURLException;
+
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
@@ -18,7 +20,7 @@ public class LoginPageTest extends TestBase{
 	}
 	
 	@BeforeMethod
-	public void setUp(){
+	public void setUp() throws MalformedURLException{
 		initialization();
 		loginPage = new LoginPage();	
 	}


### PR DESCRIPTION
Added local/remote execution type supports.
We can execute either using local browser or remote browser, for remote browser added BrowserStack Support and can be extended further.
We can toggle this setting from config.properties file. environmentType = local | remote